### PR TITLE
Avoid no such file error if protein is duplicated

### DIFF
--- a/compass/__init__.py
+++ b/compass/__init__.py
@@ -242,7 +242,7 @@ def calculate_shifts( model_list, shiftx2=None, CPUnum=8, working='./', replace 
     #create calculation subprocesses
     for i in range(len(processlist)):
         os.chdir(processlist[i].folder)
-        argument = ['python', shiftx2, '-b', '*.pdb', '-f', 'BMRB', '-a', 'ALL']
+        argument = ['/usr/bin/python', shiftx2, '-b', '*.pdb', '-f', 'BMRB', '-a', 'ALL']
         if logger:
             processlist[i].popen = subprocess.Popen( args = argument, stderr = subprocess.STDOUT, stdout = subprocess.PIPE )
         else:

--- a/compass/ros.py
+++ b/compass/ros.py
@@ -1,5 +1,5 @@
 import collections
-import os, shutil, random, string, subprocess,sys
+import os, shutil, random, string, subprocess
 
 class Job:
     '''


### PR DESCRIPTION
`os.rename(temp_path_list[i],output_list[i])`

fails if same protein is in list twice. This patch tracks which proteins have been processed and doesn't do the same one twice.